### PR TITLE
Remove debug print statements

### DIFF
--- a/telco-streamlit/telco.py
+++ b/telco-streamlit/telco.py
@@ -30,8 +30,6 @@ def shap_plot(customer_data):
 
     # Compute Shapley values for the specific customer
     shap_values = explainer.shap_values(customer_data)
-    print(customer_data.iloc[0].values)
-    print(features)
     shap_df = pd.DataFrame({"Feature" : features, "Values" : customer_data.iloc[0].values, "Shapley_Value" : shap_values[1].tolist()[0]})
     shap_df["Feature"] = shap_df["Feature"] + "=" + shap_df["Values"].astype(str)
     del shap_df["Values"]


### PR DESCRIPTION
## Summary
- clean up console output in Streamlit app by deleting noisy print statements

## Testing
- `python3 -m py_compile telco-streamlit/telco.py`

------
https://chatgpt.com/codex/tasks/task_e_68761213576c8326a177868a8f8e06f1